### PR TITLE
chore: Downgrade Kotlin 1.3 to 1.2 and coroutines from RC to experimental.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,12 @@ allOpen {
     annotation("com.mobile.sample.Mockable")
 }
 
+kotlin {
+    experimental {
+        coroutines "enable"
+    }
+}
+
 android {
     compileSdkVersion 28
     defaultConfig {
@@ -69,12 +75,12 @@ dependencies {
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutine_version"
-    implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2'
+    implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-experimental-adapter:1.0.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation "org.mockito:mockito-core:2.21.0"
+
     testImplementation "android.arch.core:core-testing:$arch_version"
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
-

--- a/app/src/main/java/com/mobile/sample/BaseViewModel.kt
+++ b/app/src/main/java/com/mobile/sample/BaseViewModel.kt
@@ -5,13 +5,17 @@ import com.mobile.sample.utils.CoroutineContextProvider
 import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Job
 
-open class BaseViewModel(contextProvider: CoroutineContextProvider) : ViewModel() {
+open class BaseViewModel(contextProvider: CoroutineContextProvider) : ViewModel(), ViewModelScope {
 
     private val job = Job()
-    val scope = CoroutineScope(contextProvider.Main + job)
+    override val scope = CoroutineScope(contextProvider.Main + job)
 
     override fun onCleared() {
         super.onCleared()
         job.cancel()
     }
+}
+
+interface ViewModelScope {
+    val scope: CoroutineScope
 }

--- a/app/src/main/java/com/mobile/sample/BaseViewModel.kt
+++ b/app/src/main/java/com/mobile/sample/BaseViewModel.kt
@@ -2,8 +2,8 @@ package com.mobile.sample
 
 import android.arch.lifecycle.ViewModel
 import com.mobile.sample.utils.CoroutineContextProvider
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.experimental.CoroutineScope
+import kotlinx.coroutines.experimental.Job
 
 open class BaseViewModel(contextProvider: CoroutineContextProvider) : ViewModel() {
 

--- a/app/src/main/java/com/mobile/sample/dagger/AppModule.kt
+++ b/app/src/main/java/com/mobile/sample/dagger/AppModule.kt
@@ -2,7 +2,7 @@ package com.mobile.sample.dagger
 
 import android.arch.persistence.room.Room
 import android.content.Context
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
+import com.jakewharton.retrofit2.adapter.kotlin.coroutines.experimental.CoroutineCallAdapterFactory
 import com.mobile.sample.MainApplication
 import com.mobile.sample.database.AppDatabase
 import com.mobile.sample.network.ApiService

--- a/app/src/main/java/com/mobile/sample/data/users/local/UserDao.kt
+++ b/app/src/main/java/com/mobile/sample/data/users/local/UserDao.kt
@@ -6,8 +6,8 @@ import android.arch.persistence.room.OnConflictStrategy.REPLACE
 import android.arch.persistence.room.Query
 import android.arch.persistence.room.Transaction
 import com.mobile.sample.data.users.User
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.experimental.coroutineScope
 
 @Dao
 abstract class UserDao {

--- a/app/src/main/java/com/mobile/sample/data/users/local/UsersLocalDataSource.kt
+++ b/app/src/main/java/com/mobile/sample/data/users/local/UsersLocalDataSource.kt
@@ -4,9 +4,8 @@ import com.mobile.sample.Mockable
 import com.mobile.sample.data.users.User
 import com.mobile.sample.data.users.UsersDataSource
 import com.mobile.sample.database.AppDatabase
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-
+import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.experimental.coroutineScope
 import javax.inject.Inject
 
 @Mockable
@@ -15,7 +14,7 @@ class UsersLocalDataSource @Inject constructor(private val database: AppDatabase
     override suspend fun getUsers() = database.userDao().getUsersAsync()
 
     suspend fun insertUsers(users: List<User>) = coroutineScope {
-        async { database.userDao().insertUsers(users) }
+        async { database.userDao().insertUsers(users) }.await()
     }
 
     suspend fun getUser(id: Int) = database.userDao().getUserAsync(id)

--- a/app/src/main/java/com/mobile/sample/main/MainActivity.kt
+++ b/app/src/main/java/com/mobile/sample/main/MainActivity.kt
@@ -5,9 +5,7 @@ import android.os.Bundle
 import android.util.Log
 import com.mobile.sample.R
 import com.mobile.sample.dagger.ViewModelFactory
-import com.mobile.sample.utils.Router
-import com.mobile.sample.utils.addDivider
-import com.mobile.sample.utils.getViewModel
+import com.mobile.sample.utils.*
 import dagger.android.support.DaggerAppCompatActivity
 import kotlinx.android.synthetic.main.activity_main.*
 import javax.inject.Inject
@@ -30,11 +28,14 @@ class MainActivity : DaggerAppCompatActivity() {
         userRecyclerView.adapter = userListAdapter
 
         usersViewModel.getUsers().observe(this, Observer { result ->
-            result?.onSuccess {
-                userListAdapter.setItemList(it)
-                userListAdapter.submitList(it)
-            }?.onFailure {
-                Log.d("ERROR", "Error is: ${it.localizedMessage}")
+            when (result) {
+                is Success -> {
+                    userListAdapter.setItemList(result.data)
+                    userListAdapter.submitList(result.data)
+                }
+                is Failure -> {
+                    Log.d("ERROR", "Error is: ${result.throwable.localizedMessage}")
+                }
             }
         })
 

--- a/app/src/main/java/com/mobile/sample/main/UsersViewModel.kt
+++ b/app/src/main/java/com/mobile/sample/main/UsersViewModel.kt
@@ -7,7 +7,8 @@ import com.mobile.sample.data.users.User
 import com.mobile.sample.data.users.UsersRepository
 import com.mobile.sample.utils.CoroutineContextProvider
 import com.mobile.sample.utils.LiveEvent
-import kotlinx.coroutines.launch
+import com.mobile.sample.utils.Result
+import kotlinx.coroutines.experimental.launch
 import javax.inject.Inject
 
 class UsersViewModel @Inject constructor(
@@ -19,9 +20,7 @@ class UsersViewModel @Inject constructor(
     private val users = MutableLiveData<Result<List<User>>>()
 
     init {
-        scope.launch {
-            usersRepository.getUsers(users)
-        }
+        scope.launch { usersRepository.getUsers(users) }
     }
 
     fun getUsers(): LiveData<Result<List<User>>> = users

--- a/app/src/main/java/com/mobile/sample/main/UsersViewModel.kt
+++ b/app/src/main/java/com/mobile/sample/main/UsersViewModel.kt
@@ -1,29 +1,25 @@
 package com.mobile.sample.main
 
 import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MutableLiveData
 import com.mobile.sample.BaseViewModel
 import com.mobile.sample.data.users.User
 import com.mobile.sample.data.users.UsersRepository
 import com.mobile.sample.utils.CoroutineContextProvider
 import com.mobile.sample.utils.LiveEvent
 import com.mobile.sample.utils.Result
-import kotlinx.coroutines.experimental.launch
 import javax.inject.Inject
 
 class UsersViewModel @Inject constructor(
         contextProvider: CoroutineContextProvider,
-        private val usersRepository: UsersRepository
+        usersRepository: UsersRepository
 ) : BaseViewModel(contextProvider), UserItemActionsListener {
 
     private val userId = LiveEvent<Int>()
-    private val users = MutableLiveData<Result<List<User>>>()
+    private val users: LiveData<Result<List<User>>> = usersRepository.getUsers(scope)
 
-    init {
-        scope.launch { usersRepository.getUsers(users) }
+    fun getUsers(): LiveData<Result<List<User>>> {
+        return users
     }
-
-    fun getUsers(): LiveData<Result<List<User>>> = users
 
     fun getUserClickedEvent(): LiveEvent<Int> = userId
 

--- a/app/src/main/java/com/mobile/sample/network/ApiService.kt
+++ b/app/src/main/java/com/mobile/sample/network/ApiService.kt
@@ -1,7 +1,7 @@
 package com.mobile.sample.network
 
 import com.mobile.sample.data.users.remote.UserRemoteModel
-import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.experimental.Deferred
 import retrofit2.http.GET
 
 interface ApiService {

--- a/app/src/main/java/com/mobile/sample/network/NetworkManager.kt
+++ b/app/src/main/java/com/mobile/sample/network/NetworkManager.kt
@@ -2,7 +2,7 @@ package com.mobile.sample.network
 
 import com.mobile.sample.Mockable
 import com.mobile.sample.data.users.remote.UserRemoteModel
-import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.experimental.Deferred
 import javax.inject.Inject
 
 @Mockable

--- a/app/src/main/java/com/mobile/sample/utils/CoroutineContextProvider.kt
+++ b/app/src/main/java/com/mobile/sample/utils/CoroutineContextProvider.kt
@@ -1,9 +1,9 @@
 package com.mobile.sample.utils
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.android.Main
-import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.IO
+import kotlinx.coroutines.experimental.android.Main
+import kotlin.coroutines.experimental.CoroutineContext
 
 open class CoroutineContextProvider {
     open val Main: CoroutineContext by lazy { Dispatchers.Main }

--- a/app/src/main/java/com/mobile/sample/utils/Result.kt
+++ b/app/src/main/java/com/mobile/sample/utils/Result.kt
@@ -1,0 +1,8 @@
+package com.mobile.sample.utils
+
+sealed class Result<T> {
+    fun get(): T? = null
+}
+
+data class Success<T>(val data: T) : Result<T>()
+data class Failure<T>(val throwable: Throwable) : Result<T>()

--- a/app/src/test/java/com/mobile/sample/data/users/UsersRepositoryTest.kt
+++ b/app/src/test/java/com/mobile/sample/data/users/UsersRepositoryTest.kt
@@ -1,7 +1,6 @@
 package com.mobile.sample.data.users
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
-import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Observer
 import com.mobile.sample.data.users.local.UserLocalModel
 import com.mobile.sample.data.users.local.UsersLocalDataSource
@@ -49,13 +48,12 @@ class UsersRepositoryTest {
     }
 
     @Test
-    fun getUsers_hasLocalUsers_setUsersLiveData() = runBlocking {
-        // Given
-        val usersData = MutableLiveData<Result<List<User>>>()
-
+    fun getUsers_hasLocalUsers_setUsersLiveData() {
         // When
-        `when`(localDataSource.getUsers()).thenReturn(userList)
-        usersRepository.getUsers(usersData)
+        val usersData = runBlocking {
+            `when`(localDataSource.getUsers()).thenReturn(userList)
+            usersRepository.getUsers(this)
+        }
         usersData.observeForever(observer)
 
         // Then
@@ -64,14 +62,13 @@ class UsersRepositoryTest {
 
     @Test
     fun getUsers_noLocalUsers_fetchFromNetwork() = runBlocking {
-        // Given
-        val usersData = MutableLiveData<Result<List<User>>>()
-
         // When
-        `when`(localDataSource.getUsers()).thenReturn(emptyList())
-        `when`(remoteDataSource.getUsers()).thenReturn(remoteUserList)
+        val usersData = runBlocking {
+            `when`(localDataSource.getUsers()).thenReturn(emptyList())
+            `when`(remoteDataSource.getUsers()).thenReturn(remoteUserList)
+            usersRepository.getUsers(this)
+        }
 
-        usersRepository.getUsers(usersData)
         usersData.observeForever(observer)
 
         // Then
@@ -82,14 +79,15 @@ class UsersRepositoryTest {
     }
 
     @Test
-    fun getUsers_fetchLocalUsersError_catchError() = runBlocking {
+    fun getUsers_fetchLocalUsersError_catchError() {
         // Given
-        val usersData = MutableLiveData<Result<List<User>>>()
         val error = Throwable("error from DB")
 
         // When
-        `when`(localDataSource.getUsers()).thenAnswer { throw error }
-        usersRepository.getUsers(usersData)
+        val usersData = runBlocking {
+            `when`(localDataSource.getUsers()).thenAnswer { throw error }
+            usersRepository.getUsers(this)
+        }
         usersData.observeForever(observer)
 
         // Then

--- a/app/src/test/java/com/mobile/sample/data/users/remote/TestCoroutineContextProvider.kt
+++ b/app/src/test/java/com/mobile/sample/data/users/remote/TestCoroutineContextProvider.kt
@@ -1,8 +1,8 @@
 package com.mobile.sample.data.users.remote
 
 import com.mobile.sample.utils.CoroutineContextProvider
-import kotlinx.coroutines.Dispatchers
-import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlin.coroutines.experimental.CoroutineContext
 
 class TestCoroutineContextProvider : CoroutineContextProvider() {
     override val Main: CoroutineContext = Dispatchers.Unconfined

--- a/app/src/test/java/com/mobile/sample/main/UsersViewModelTest.kt
+++ b/app/src/test/java/com/mobile/sample/main/UsersViewModelTest.kt
@@ -2,13 +2,15 @@ package com.mobile.sample.main
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
-import com.mobile.sample.data.users.User
 import com.mobile.sample.data.users.UsersRepository
 import com.mobile.sample.data.users.remote.TestCoroutineContextProvider
 import org.junit.Before
 import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
+import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
@@ -24,36 +26,22 @@ class UsersViewModelTest {
     @Mock
     private lateinit var observer: Observer<Int>
 
-    @Mock
-    private lateinit var userListObserver: Observer<List<User>>
-
     private lateinit var userViewModel: UsersViewModel
 
     @Before
     fun setUp() {
         userViewModel = UsersViewModel(TestCoroutineContextProvider(), repository)
+
     }
 
-//    @Test
-//    fun onUserClicked_callObserverOnChanged() {
-//        userViewModel.onUserClicked(Mockito.anyInt())
-//
-//        val userClickedEvent = userViewModel.getUserClickedEvent()
-//        userClickedEvent.observeForever(observer)
-//
-//        Mockito.verify(observer).onChanged(Mockito.anyInt())
-//    }
-//
-//    @Test
-//    fun getUsers_hasData_callObserverOnChanged() {
-//        val data = MutableLiveData<List<User>>()
-//        data.value = emptyList()
-//
-//        Mockito.`when`(repository.getUsers(users)).thenReturn(data)
-//
-//        val users = userViewModel.getUsers()
-//        users.observeForever(userListObserver)
-//
-//        Mockito.verify(userListObserver).onChanged(emptyList())
-//    }
+    @Test
+    fun onUserClicked_callObserverOnChanged() {
+        // When
+        userViewModel.onUserClicked(anyInt())
+        val userClickedEvent = userViewModel.getUserClickedEvent()
+        userClickedEvent.observeForever(observer)
+
+        // Then
+        verify(observer).onChanged(anyInt())
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.2.70'
     ext.support_version = '28.0.0'
     ext.arch_version = '1.1.1'
     ext.room_version = '1.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.0-rc-57'
+    ext.kotlin_version = '1.2.61'
     ext.support_version = '28.0.0'
     ext.arch_version = '1.1.1'
     ext.room_version = '1.1.1'
     ext.dagger_version = '2.16'
     ext.retrofit_version = '2.4.0'
-    ext.coroutine_version = '0.26.1-eap13'
+    ext.coroutine_version = '0.26.1'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
When trying the new version of Kotlin 1.3 and Coroutines 0.26.1-eap13 I am unable to get Mockito to work properly with suspend functions. Mocked object function calls are not returning their desired answers. 

However downgrading back to Kotlin 1.2 and Coroutines 0.26.1 seems to fix these issues as this PR mostly just changes the from 0.26.1-eap13 back to experimental and removes Kotlin 1.3 Result class as it is not able to be used in Kotlin 1.2